### PR TITLE
Render complex text, variant forms, emoji, etc.

### DIFF
--- a/build/generate-unicode-data.ts
+++ b/build/generate-unicode-data.ts
@@ -401,9 +401,10 @@ export function codePointRequiresComplexTextShaping(codePoint: number): boolean 
  * Returns whether two grapheme clusters detected by \`Intl.Segmenter\` can be combined to prevent an invisible combining mark from appearing unexpectedly.
  */
 export function canCombineGraphemes(former: string, latter: string): boolean {
+    // Zero-width joiner
     // Indic_Syllabic_Category=Invisible_Stacker as of Unicode ${indicSyllabicCategory.version}, published ${indicSyllabicCategory.date}.
     // eslint-disable-next-line no-misleading-character-class
-    const invisibleStackersRegExp = /[${indicSyllabicCategory.characterClass}]$/u;
-    return invisibleStackersRegExp.test(former) || /^\\p{gc=Mc}/u.test(latter);
+    const terminalJoinersRegExp = /[\\u200D${indicSyllabicCategory.characterClass}]$/u;
+    return terminalJoinersRegExp.test(former) || /^\\p{gc=Mc}/u.test(latter);
 }
 `);

--- a/build/generate-unicode-data.ts
+++ b/build/generate-unicode-data.ts
@@ -1,6 +1,9 @@
 import * as fs from 'fs';
 import * as regenerate from 'regenerate';
 
+// Or https://www.unicode.org/Public/draft/UCD/ucd if the next Unicode version is finalized and awaiting publication.
+const ucdBaseUrl = 'https://www.unicode.org/Public/UCD/latest/ucd';
+
 /**
  * The heuristics in the functions below are based on this version of the
  * Unicode Standard. This constant should match the `@unicode/unicode-*` package
@@ -313,6 +316,32 @@ async function requiresComplexTextShaping(): Promise<string> {
     return set.toString();
 }
 
+async function getPropertyData(property: string, value: string): Promise<{[_: string]: string}> {
+    const indicSyllabicCategoryUrl = `${ucdBaseUrl}/${property.replaceAll('_', '')}.txt`;
+    const response = await fetch(indicSyllabicCategoryUrl);
+    if (!response.ok) {
+        throw new Error(`Unable to fetch latest Unicode character database file for ${property}: ${response.status}`);
+    }
+
+    const table = await response.text();
+    const header = table.match(/^# \w+-(\d+\.\d+\.\d+)\.txt\n# Date: (\d\d\d\d-\d\d-\d\d)/);
+    const tableRegExp = new RegExp(`^([0-9A-Z]{4,6}(?:..[0-9A-Z]{4,6})?)(?= *; ${value})`, 'gm');
+    const characterClass = table
+        .match(tableRegExp)
+        .map(record => record
+            .split('..')
+            .map(codePoint => (codePoint.length > 4) ? `\\u{${codePoint}}` : `\\u${codePoint}`)
+            .join('-'))
+        .join('');
+    return {
+        version: header && header[1],
+        date: header && header[2],
+        characterClass,
+    };
+}
+
+const indicSyllabicCategory = await getPropertyData('Indic_Syllabic_Category', 'Invisible_Stacker');
+
 fs.writeFileSync('src/util/unicode_properties.g.ts',
     `// This file is generated. Edit build/generate-unicode-data.ts, then run \`npm run generate-unicode-data\`.
 
@@ -366,5 +395,15 @@ export function codePointHasNeutralVerticalOrientation(codePoint: number): boole
  */
 export function codePointRequiresComplexTextShaping(codePoint: number): boolean {
     return /${await requiresComplexTextShaping()}/gim.test(String.fromCodePoint(codePoint));
+}
+
+/**
+ * Returns whether two grapheme clusters detected by \`Intl.Segmenter\` can be combined to prevent an invisible combining mark from appearing unexpectedly.
+ */
+export function canCombineGraphemes(former: string, latter: string): boolean {
+    // Indic_Syllabic_Category=Invisible_Stacker as of Unicode ${indicSyllabicCategory.version}, published ${indicSyllabicCategory.date}.
+    // eslint-disable-next-line no-misleading-character-class
+    const invisibleStackersRegExp = /[${indicSyllabicCategory.characterClass}]$/u;
+    return invisibleStackersRegExp.test(former) || /^\\p{gc=Mc}/u.test(latter);
 }
 `);

--- a/src/data/bucket/symbol_bucket.test.ts
+++ b/src/data/bucket/symbol_bucket.test.ts
@@ -24,7 +24,7 @@ transform.resize(100, 100);
 
 const stacks = {'Test': glyphs} as any as {
     [_: string]: {
-        [x: number]: StyleGlyph;
+        [x: string]: StyleGlyph;
     };
 };
 

--- a/src/data/bucket/symbol_bucket.ts
+++ b/src/data/bucket/symbol_bucket.ts
@@ -106,6 +106,8 @@ const shaderOpacityAttributes = [
     {name: 'a_fade_opacity', components: 1, type: 'Uint8' as ViewType, offset: 0}
 ];
 
+const segmenter = new Intl.Segmenter();
+
 function addVertex(
     array: StructArray,
     anchorX: number,
@@ -413,17 +415,17 @@ export class SymbolBucket implements Bucket {
 
     private calculateGlyphDependencies(
         text: string,
-        stack: {[_: number]: boolean},
+        stack: {[_: string]: boolean},
         textAlongLine: boolean,
         allowVerticalPlacement: boolean,
         doesAllowVerticalWritingMode: boolean) {
 
-        for (const char of text) {
-            stack[char.codePointAt(0)] = true;
+        for (const {segment} of segmenter.segment(text)) {
+            stack[segment] = true;
             if ((textAlongLine || allowVerticalPlacement) && doesAllowVerticalWritingMode) {
-                const verticalChar = verticalizedCharacterMap[char];
+                const verticalChar = verticalizedCharacterMap[segment];
                 if (verticalChar) {
-                    stack[verticalChar.codePointAt(0)] = true;
+                    stack[segment] = true;
                 }
             }
         }

--- a/src/data/bucket/symbol_bucket.ts
+++ b/src/data/bucket/symbol_bucket.ts
@@ -23,7 +23,7 @@ import {ProgramConfigurationSet} from '../program_configuration';
 import {TriangleIndexArray, LineIndexArray} from '../index_array_type';
 import {transformText} from '../../symbol/transform_text';
 import {mergeLines} from '../../symbol/merge_lines';
-import {allowsVerticalWritingMode, stringContainsRTLText} from '../../util/script_detection';
+import {allowsVerticalWritingMode, splitByGraphemeCluster, stringContainsRTLText} from '../../util/script_detection';
 import {WritingMode} from '../../symbol/shaping';
 import {loadGeometry} from '../load_geometry';
 import {toEvaluationFeature} from '../evaluation_feature';
@@ -105,8 +105,6 @@ export type SortKeyRange = {
 const shaderOpacityAttributes = [
     {name: 'a_fade_opacity', components: 1, type: 'Uint8' as ViewType, offset: 0}
 ];
-
-const segmenter = new Intl.Segmenter();
 
 function addVertex(
     array: StructArray,
@@ -420,7 +418,7 @@ export class SymbolBucket implements Bucket {
         allowVerticalPlacement: boolean,
         doesAllowVerticalWritingMode: boolean) {
 
-        for (const {segment} of segmenter.segment(text)) {
+        for (const {segment} of splitByGraphemeCluster(text)) {
             stack[segment] = true;
             if ((textAlongLine || allowVerticalPlacement) && doesAllowVerticalWritingMode) {
                 const verticalChar = verticalizedCharacterMap[segment];

--- a/src/data/unicode_properties.ts
+++ b/src/data/unicode_properties.ts
@@ -4,8 +4,9 @@
  * Returns whether two grapheme clusters detected by `Intl.Segmenter` can be combined to prevent an invisible combining mark from appearing unexpectedly.
  */
 export function canCombineGraphemes(former: string, latter: string): boolean {
+    // Zero-width joiner
     // Indic_Syllabic_Category=Invisible_Stacker as of Unicode 16.0.0, published 2024-04-30.
     // eslint-disable-next-line no-misleading-character-class
-    const invisibleStackersRegExp = /[\u1039\u17D2\u1A60\u1BAB\uAAF6\u{10A3F}\u{11133}\u{113D0}\u{1193E}\u{11A47}\u{11A99}\u{11D45}\u{11D97}\u{11F42}]$/u;
-    return invisibleStackersRegExp.test(former) || /^\p{gc=Mc}/u.test(latter);
+    const terminalJoinersRegExp = /[\u200D\u1039\u17D2\u1A60\u1BAB\uAAF6\u{10A3F}\u{11133}\u{113D0}\u{1193E}\u{11A47}\u{11A99}\u{11D45}\u{11D97}\u{11F42}]$/u;
+    return terminalJoinersRegExp.test(former) || /^\p{gc=Mc}/u.test(latter);
 }

--- a/src/data/unicode_properties.ts
+++ b/src/data/unicode_properties.ts
@@ -1,0 +1,11 @@
+// This file is generated. Edit build/generate-unicode-data.ts, then run `npm run generate-unicode-data`.
+
+/**
+ * Returns whether two grapheme clusters detected by `Intl.Segmenter` can be combined to prevent an invisible combining mark from appearing unexpectedly.
+ */
+export function canCombineGraphemes(former: string, latter: string): boolean {
+    // Indic_Syllabic_Category=Invisible_Stacker as of Unicode 16.0.0, published 2024-04-30.
+    // eslint-disable-next-line no-misleading-character-class
+    const invisibleStackersRegExp = /[\u1039\u17D2\u1A60\u1BAB\uAAF6\u{10A3F}\u{11133}\u{113D0}\u{1193E}\u{11A47}\u{11A99}\u{11D45}\u{11D97}\u{11F42}]$/u;
+    return invisibleStackersRegExp.test(former) || /^\p{gc=Mc}/u.test(latter);
+}

--- a/src/render/glyph_atlas.ts
+++ b/src/render/glyph_atlas.ts
@@ -30,7 +30,7 @@ export type GlyphPosition = {
  */
 export type GlyphPositions = {
     [_: string]: {
-        [_: number]: GlyphPosition;
+        [_: string]: GlyphPosition;
     };
 };
 
@@ -46,8 +46,8 @@ export class GlyphAtlas {
             const glyphs = stacks[stack];
             const stackPositions = positions[stack] = {};
 
-            for (const id in glyphs) {
-                const src = glyphs[+id];
+            for (const grapheme in glyphs) {
+                const src = glyphs[grapheme];
                 if (!src || src.bitmap.width === 0 || src.bitmap.height === 0) continue;
 
                 const bin = {
@@ -57,7 +57,7 @@ export class GlyphAtlas {
                     h: src.bitmap.height + 2 * padding
                 };
                 bins.push(bin);
-                stackPositions[id] = {rect: bin, metrics: src.metrics};
+                stackPositions[grapheme] = {rect: bin, metrics: src.metrics};
             }
         }
 
@@ -67,10 +67,10 @@ export class GlyphAtlas {
         for (const stack in stacks) {
             const glyphs = stacks[stack];
 
-            for (const id in glyphs) {
-                const src = glyphs[+id];
+            for (const grapheme in glyphs) {
+                const src = glyphs[grapheme];
                 if (!src || src.bitmap.width === 0 || src.bitmap.height === 0) continue;
-                const bin = positions[stack][id].rect;
+                const bin = positions[stack][grapheme].rect;
                 AlphaImage.copy(src.bitmap, image, {x: 0, y: 0}, {x: bin.x + padding, y: bin.y + padding}, src.bitmap);
             }
         }

--- a/src/render/glyph_manager.test.ts
+++ b/src/render/glyph_manager.test.ts
@@ -7,7 +7,7 @@ import {type RequestManager} from '../util/request_manager';
 describe('GlyphManager', () => {
     const GLYPHS = {};
     for (const glyph of parseGlyphPbf(fs.readFileSync('./test/unit/assets/0-255.pbf'))) {
-        GLYPHS[glyph.id] = glyph;
+        GLYPHS[glyph.grapheme] = glyph;
     }
 
     const identityTransform = ((url) => ({url})) as any as RequestManager;
@@ -38,22 +38,22 @@ describe('GlyphManager', () => {
         createLoadGlyphRangeStub();
         const manager = createGlyphManager(true);
 
-        const returnedGlyphs = await manager.getGlyphs({'Arial Unicode MS': [55]});
-        expect(returnedGlyphs['Arial Unicode MS']['55'].metrics.advance).toBe(12);
+        const returnedGlyphs = await manager.getGlyphs({'Arial Unicode MS': ['7']});
+        expect(returnedGlyphs['Arial Unicode MS']['7'].metrics.advance).toBe(12);
     });
 
     test('GlyphManager doesn\'t request twice 0-255 PBF if a glyph is missing', async () => {
         const stub = createLoadGlyphRangeStub();
         const manager = createGlyphManager(true);
 
-        await manager.getGlyphs({'Arial Unicode MS': [0.5]});
+        await manager.getGlyphs({'Arial Unicode MS': ['\0']});
         expect(manager.entries['Arial Unicode MS'].ranges[0]).toBe(true);
         expect(stub).toHaveBeenCalledTimes(1);
 
         // We remove all requests as in getGlyphs code.
         delete manager.entries['Arial Unicode MS'].requests[0];
 
-        await manager.getGlyphs({'Arial Unicode MS': [0.5]});
+        await manager.getGlyphs({'Arial Unicode MS': ['\0']});
         expect(manager.entries['Arial Unicode MS'].ranges[0]).toBe(true);
         expect(stub).toHaveBeenCalledTimes(1);
     });
@@ -65,8 +65,8 @@ describe('GlyphManager', () => {
 
         const manager = createGlyphManager(true);
 
-        const returnedGlyphs = await manager.getGlyphs({'Arial Unicode MS': [0x5e73]});
-        expect(returnedGlyphs['Arial Unicode MS'][0x5e73]).toBeNull(); // The fixture returns a PBF without the glyph we requested
+        const returnedGlyphs = await manager.getGlyphs({'Arial Unicode MS': ['平']});
+        expect(returnedGlyphs['Arial Unicode MS']['平']).toBeNull(); // The fixture returns a PBF without the glyph we requested
     });
 
     test('GlyphManager requests remote non-BMP, non-CJK PBF', async () => {
@@ -77,8 +77,8 @@ describe('GlyphManager', () => {
         const manager = createGlyphManager(true);
 
         // Request Egyptian hieroglyph 𓃰
-        const returnedGlyphs = await manager.getGlyphs({'Arial Unicode MS': [0x1e0f0]});
-        expect(returnedGlyphs['Arial Unicode MS'][0x1e0f0]).toBeNull(); // The fixture returns a PBF without the glyph we requested
+        const returnedGlyphs = await manager.getGlyphs({'Arial Unicode MS': ['𓃰']});
+        expect(returnedGlyphs['Arial Unicode MS']['𓃰']).toBeNull(); // The fixture returns a PBF without the glyph we requested
     });
 
     test('GlyphManager does not cache CJK chars that should be rendered locally', async () => {
@@ -87,6 +87,7 @@ describe('GlyphManager', () => {
             const start = range * 256;
             const end = start + 256;
             for (let i = start, j = 0; i < end; i++, j++) {
+                const grapheme = String.fromCodePoint(i);
                 overlappingGlyphs[i] = GLYPHS[j];
             }
             return Promise.resolve(overlappingGlyphs);
@@ -95,11 +96,11 @@ describe('GlyphManager', () => {
         const manager = createGlyphManager(true, 'sans-serif');
 
         //Request char that overlaps Katakana range
-        let returnedGlyphs = await manager.getGlyphs({'Arial Unicode MS': [0x3005]});
-        expect(returnedGlyphs['Arial Unicode MS'][0x3005]).not.toBeNull();
+        let returnedGlyphs = await manager.getGlyphs({'Arial Unicode MS': ['々']});
+        expect(returnedGlyphs['Arial Unicode MS']['々']).not.toBeNull();
         //Request char from Katakana range (te テ)
-        returnedGlyphs = await manager.getGlyphs({'Arial Unicode MS': [0x30C6]});
-        const glyph = returnedGlyphs['Arial Unicode MS'][0x30c6];
+        returnedGlyphs = await manager.getGlyphs({'Arial Unicode MS': ['テ']});
+        const glyph = returnedGlyphs['Arial Unicode MS']['テ'];
         //Ensure that te is locally generated.
         expect(glyph.bitmap.height).toBe(12);
         expect(glyph.bitmap.width).toBe(12);
@@ -109,32 +110,32 @@ describe('GlyphManager', () => {
         const manager = createGlyphManager(true, 'sans-serif');
 
         // Chinese character píng 平
-        const returnedGlyphs = await manager.getGlyphs({'Arial Unicode MS': [0x5e73]});
-        expect(returnedGlyphs['Arial Unicode MS'][0x5e73].metrics.advance).toBe(0.5);
+        const returnedGlyphs = await manager.getGlyphs({'Arial Unicode MS': ['平']});
+        expect(returnedGlyphs['Arial Unicode MS']['平'].metrics.advance).toBe(0.5);
     });
 
     test('GlyphManager generates non-BMP CJK PBF locally', async () => {
         const manager = createGlyphManager(true, 'sans-serif');
 
         // Chinese character biáng 𰻞
-        const returnedGlyphs = await manager.getGlyphs({'Arial Unicode MS': [0x30EDE]});
-        expect(returnedGlyphs['Arial Unicode MS'][0x30EDE].metrics.advance).toBe(1);
+        const returnedGlyphs = await manager.getGlyphs({'Arial Unicode MS': ['𰻞']});
+        expect(returnedGlyphs['Arial Unicode MS']['𰻞'].metrics.advance).toBe(1);
     });
 
     test('GlyphManager generates Katakana PBF locally', async () => {
         const manager = createGlyphManager(true, 'sans-serif');
 
         // Katakana letter te テ
-        const returnedGlyphs = await manager.getGlyphs({'Arial Unicode MS': [0x30c6]});
-        expect(returnedGlyphs['Arial Unicode MS'][0x30c6].metrics.advance).toBe(0.5);
+        const returnedGlyphs = await manager.getGlyphs({'Arial Unicode MS': ['テ']});
+        expect(returnedGlyphs['Arial Unicode MS']['テ'].metrics.advance).toBe(0.5);
     });
 
     test('GlyphManager generates Hiragana PBF locally', async () => {
         const manager = createGlyphManager(true, 'sans-serif');
 
         //Hiragana letter te て
-        const returnedGlyphs = await manager.getGlyphs({'Arial Unicode MS': [0x3066]});
-        expect(returnedGlyphs['Arial Unicode MS'][0x3066].metrics.advance).toBe(0.5);
+        const returnedGlyphs = await manager.getGlyphs({'Arial Unicode MS': ['て']});
+        expect(returnedGlyphs['Arial Unicode MS']['て'].metrics.advance).toBe(0.5);
     });
 
     test('GlyphManager consistently generates CJKV text locally', async () => {
@@ -164,18 +165,18 @@ describe('GlyphManager', () => {
         const manager = createGlyphManager(false, 'sans-serif');
 
         // A
-        const returnedGlyphs = await manager.getGlyphs({'Times Old Roman': [0x41]});
-        expect(returnedGlyphs['Times Old Roman'][0x41].metrics.width).toBeGreaterThan(0);
-        expect(returnedGlyphs['Times Old Roman'][0x41].metrics.advance).toBeGreaterThan(0);
+        const returnedGlyphs = await manager.getGlyphs({'Times Old Roman': ['A']});
+        expect(returnedGlyphs['Times Old Roman']['A'].metrics.width).toBeGreaterThan(0);
+        expect(returnedGlyphs['Times Old Roman']['A'].metrics.advance).toBeGreaterThan(0);
     });
 
     test('GlyphManager locally generates nonspacing control character', async () => {
         const manager = createGlyphManager(false, 'sans-serif');
 
         // U+202E RIGHT-TO-LEFT OVERRIDE
-        const returnedGlyphs = await manager.getGlyphs({'Ctrl Alt Del': [0x202e]});
-        expect(returnedGlyphs['Ctrl Alt Del'][0x202e].metrics.width).toBe(0);
-        expect(returnedGlyphs['Ctrl Alt Del'][0x202e].metrics.advance).toBe(0);
+        const returnedGlyphs = await manager.getGlyphs({'Ctrl Alt Del': ['\u202e']});
+        expect(returnedGlyphs['Ctrl Alt Del']['\u202e'].metrics.width).toBe(0);
+        expect(returnedGlyphs['Ctrl Alt Del']['\u202e'].metrics.advance).toBe(0);
     });
 
     test('GlyphManager matches font styles', async () => {
@@ -200,8 +201,8 @@ describe('GlyphManager', () => {
     test('GlyphManager generates missing PBF locally', async () => {
         const manager = createGlyphManager(true, 'sans-serif');
 
-        const returnedGlyphs = await manager.getGlyphs({'Arial Unicode MS': [0x10e1]});
-        expect(returnedGlyphs['Arial Unicode MS'][0x10e1].metrics.advance).toBe(12);
+        const returnedGlyphs = await manager.getGlyphs({'Arial Unicode MS': ['ს']});
+        expect(returnedGlyphs['Arial Unicode MS']['ს'].metrics.advance).toBe(12);
     });
 
     test('GlyphManager caches locally generated glyphs', async () => {
@@ -212,31 +213,31 @@ describe('GlyphManager', () => {
         });
 
         // Katakana letter te
-        const returnedGlyphs = await manager.getGlyphs({'Arial Unicode MS': [0x30c6]});
-        expect(returnedGlyphs['Arial Unicode MS'][0x30c6].metrics.advance).toBe(24);
-        await manager.getGlyphs({'Arial Unicode MS': [0x30c6]});
+        const returnedGlyphs = await manager.getGlyphs({'Arial Unicode MS': ['テ']});
+        expect(returnedGlyphs['Arial Unicode MS']['テ'].metrics.advance).toBe(24);
+        await manager.getGlyphs({'Arial Unicode MS': ['テ']});
         expect(drawSpy).toHaveBeenCalledTimes(1);
     });
 
     test('GlyphManager passes no language to TinySDF by default', async () => {
         const langSpy = GlyphManager.TinySDF = vi.fn().mockImplementation(function () {
             return {
-                draw: () => GLYPHS[0]
+                draw: () => GLYPHS['\0']
             };
         });
         const manager = createGlyphManager(true, 'sans-serif');
-        await manager.getGlyphs({'Arial Unicode MS': [0x30c6]});
+        await manager.getGlyphs({'Arial Unicode MS': ['テ']});
         expect(langSpy).toHaveBeenCalledWith(expect.not.objectContaining({lang: expect.anything()}));
     });
 
     test('GlyphManager sets the language on TinySDF', async () => {
         const langSpy = GlyphManager.TinySDF = vi.fn().mockImplementation(function () {
             return {
-                draw: () => GLYPHS[0]
+                draw: () => GLYPHS['\0']
             };
         });
         const manager = createGlyphManager(true, 'sans-serif', 'zh');
-        await manager.getGlyphs({'Arial Unicode MS': [0x30c6]});
+        await manager.getGlyphs({'Arial Unicode MS': ['テ']});
         expect(langSpy).toHaveBeenCalledWith(expect.objectContaining({lang: 'zh'}));
     });
 });

--- a/src/render/glyph_manager.ts
+++ b/src/render/glyph_manager.ts
@@ -143,7 +143,7 @@ export class GlyphManager {
             const response = await entry.requests[range];
             for (const responseGrapheme in response) {
                 // FIXME: Whyyyyy??
-                const key = responseGrapheme.length > 1 ? String.fromCodePoint(responseGrapheme) : responseGrapheme;
+                const key = responseGrapheme.length > 1 ? String.fromCodePoint(+responseGrapheme) : responseGrapheme;
                 entry.glyphs[key] = response[responseGrapheme];
             }
             entry.ranges[range] = true;

--- a/src/render/glyph_manager.ts
+++ b/src/render/glyph_manager.ts
@@ -221,7 +221,7 @@ export class GlyphManager {
 
         return new GlyphManager.TinySDF({
             fontSize: 24 * textureScale,
-            buffer: 3 * textureScale,
+            buffer: 8 * textureScale,
             radius: 8 * textureScale,
             cutoff: 0.25,
             fontFamily: fontFamily,

--- a/src/render/glyph_manager.ts
+++ b/src/render/glyph_manager.ts
@@ -177,34 +177,14 @@ export class GlyphManager {
         entry[tinySDFKey] ||= this._createTinySDF(usesLocalIdeographFontFamily ? this.localIdeographFontFamily : stack);
         const char = entry[tinySDFKey].draw(grapheme);
 
-        /**
-         * TinySDF's "top" is the distance from the alphabetic baseline to the top of the glyph.
-         * Server-generated fonts specify "top" relative to an origin above the em box (the origin
-         * comes from FreeType, but I'm unclear on exactly how it's derived)
-         * ref: https://github.com/mapbox/sdf-glyph-foundry
-         *
-         * Server fonts don't yet include baseline information, so we can't line up exactly with them
-         * (and they don't line up with each other)
-         * ref: https://github.com/mapbox/node-fontnik/pull/160
-         *
-         * To approximately align TinySDF glyphs with server-provided glyphs, we use this baseline adjustment
-         * factor calibrated to be in between DIN Pro and Arial Unicode (but closer to Arial Unicode)
-         */
-        const topAdjustment = 27.5;
-
-        const leftAdjustment = 0.5;
-
-        // By definition, control characters are invisible and nonspacing.
-        const isControl = /^\p{gc=Cf}+$/u.test(String.fromCodePoint(id));
-
         return {
             grapheme,
             bitmap: new AlphaImage({width: char.width || 30 * textureScale, height: char.height || 30 * textureScale}, char.data),
             metrics: {
                 width: isControl ? 0 : (char.glyphWidth / textureScale || 24),
                 height: char.glyphHeight / textureScale || 24,
-                left: (char.glyphLeft / textureScale + leftAdjustment) || 0,
-                top: char.glyphTop / textureScale - topAdjustment || -8,
+                left: char.glyphLeft / textureScale || 0,
+                top: char.glyphTop / textureScale || 0,
                 advance: isControl ? 0 : (char.glyphAdvance / textureScale || 24),
                 isDoubleResolution: true
             }

--- a/src/render/glyph_manager.ts
+++ b/src/render/glyph_manager.ts
@@ -14,10 +14,10 @@ import {v8} from '@maplibre/maplibre-gl-style-spec';
 type Entry = {
     // null means we've requested the range, but the glyph wasn't included in the result.
     glyphs: {
-        [id: number]: StyleGlyph | null;
+        [grapheme: string]: StyleGlyph | null;
     };
     requests: {
-        [range: number]: Promise<{[_: number]: StyleGlyph | null}>;
+        [range: number]: Promise<{[_: string]: StyleGlyph | null}>;
     };
     ranges: {
         [range: number]: boolean | null;
@@ -64,12 +64,12 @@ export class GlyphManager {
         this.url = url;
     }
 
-    async getGlyphs(glyphs: {[stack: string]: Array<number>}): Promise<GetGlyphsResponse> {
-        const glyphsPromises: Promise<{stack: string; id: number; glyph: StyleGlyph}>[] = [];
+    async getGlyphs(glyphs: {[stack: string]: Array<string>}): Promise<GetGlyphsResponse> {
+        const glyphsPromises: Promise<{stack: string; grapheme: string; glyph: StyleGlyph}>[] = [];
 
         for (const stack in glyphs) {
-            for (const id of glyphs[stack]) {
-                glyphsPromises.push(this._getAndCacheGlyphsPromise(stack, id));
+            for (const grapheme of glyphs[stack]) {
+                glyphsPromises.push(this._getAndCacheGlyphsPromise(stack, grapheme));
             }
         }
 
@@ -77,13 +77,13 @@ export class GlyphManager {
 
         const result: GetGlyphsResponse = {};
 
-        for (const {stack, id, glyph} of updatedGlyphs) {
+        for (const {stack, grapheme, glyph} of updatedGlyphs) {
             if (!result[stack]) {
                 result[stack] = {};
             }
             // Clone the glyph so that our own copy of its ArrayBuffer doesn't get transferred.
-            result[stack][id] = glyph && {
-                id: glyph.id,
+            result[stack][grapheme] = glyph && {
+                grapheme: glyph.grapheme,
                 bitmap: glyph.bitmap.clone(),
                 metrics: glyph.metrics
             };
@@ -92,7 +92,7 @@ export class GlyphManager {
         return result;
     }
 
-    async _getAndCacheGlyphsPromise(stack: string, id: number): Promise<{stack: string; id: number; glyph: StyleGlyph}> {
+    async _getAndCacheGlyphsPromise(stack: string, grapheme: string): Promise<{stack: string; grapheme: string; glyph: StyleGlyph}> {
         // Create an entry for this fontstack if it doesn’t already exist.
         let entry = this.entries[stack];
         if (!entry) {
@@ -103,27 +103,28 @@ export class GlyphManager {
             };
         }
 
-        // Try to get the glyph from the cache of client-side glyphs by codepoint.
-        let glyph = entry.glyphs[id];
+        // Try to get the glyph from the cache of client-side glyphs by grapheme.
+        let glyph = entry.glyphs[grapheme];
         if (glyph !== undefined) {
-            return {stack, id, glyph};
+            return {stack, grapheme, glyph};
         }
 
-        // If the style hasn’t opted into server-side fonts or this codepoint is CJK, draw the glyph locally and cache it.
-        if (!this.url || this._charUsesLocalIdeographFontFamily(id)) {
-            glyph = entry.glyphs[id] = this._drawGlyph(entry, stack, id);
-            return {stack, id, glyph};
+        // Draw the glyph locally and cache it if necessary.
+        if (!this.url || [...grapheme].length > 1 || this._charUsesLocalIdeographFontFamily(grapheme.codePointAt(0))) {
+            glyph = entry.glyphs[grapheme] = this._drawGlyph(entry, stack, grapheme);
+            return {stack, grapheme, glyph};
         }
 
-        return await this._downloadAndCacheRangePromise(stack, id);
+        return await this._downloadAndCacheRangePromise(stack, grapheme);
     }
 
-    async _downloadAndCacheRangePromise(stack: string, id: number): Promise<{stack: string; id: number; glyph: StyleGlyph}> {
+    async _downloadAndCacheRangePromise(stack: string, grapheme: string): Promise<{stack: string; grapheme: string; glyph: StyleGlyph}> {
         // Try to get the glyph from the cache of server-side glyphs by PBF range.
         const entry = this.entries[stack];
+        const id = grapheme.codePointAt(0);
         const range = Math.floor(id / 256);
         if (entry.ranges[range]) {
-            return {stack, id, glyph: null};
+            return {stack, grapheme, glyph: null};
         }
 
         // Start downloading this range unless we’re currently downloading it.
@@ -135,20 +136,22 @@ export class GlyphManager {
         try {
             // Get the response and cache the glyphs from it.
             const response = await entry.requests[range];
-            for (const id in response) {
-                entry.glyphs[+id] = response[+id];
+            for (const responseGrapheme in response) {
+                // FIXME: Whyyyyy??
+                const key = responseGrapheme.length > 1 ? String.fromCodePoint(responseGrapheme) : responseGrapheme;
+                entry.glyphs[key] = response[responseGrapheme];
             }
             entry.ranges[range] = true;
-            return {stack, id, glyph: response[id] || null};
+            return {stack, grapheme, glyph: response[grapheme] || null};
         } catch (e) {
+            this._warnOnMissingGlyphRange(range, id, e);
             // Fall back to drawing the glyph locally and caching it.
-            const glyph = entry.glyphs[id] = this._drawGlyph(entry, stack, id);
-            this._warnOnMissingGlyphRange(glyph, range, id, e);
-            return {stack, id, glyph};
+            const glyph = entry.glyphs[grapheme] = this._drawGlyph(entry, stack, grapheme);
+            return {stack, grapheme, glyph};
         }
     }
 
-    _warnOnMissingGlyphRange(glyph: StyleGlyph, range: number, id: number, err: Error) {
+    _warnOnMissingGlyphRange(range: number, id: number, err: Error) {
         const begin = range * 256;
         const end = begin + 255;
         const codePoint = id.toString(16).padStart(4, '0').toUpperCase();
@@ -165,14 +168,14 @@ export class GlyphManager {
     /**
      * Draws a glyph offscreen using TinySDF, creating a TinySDF instance lazily.
      */
-    _drawGlyph(entry: Entry, stack: string, id: number): StyleGlyph {
+    _drawGlyph(entry: Entry, stack: string, grapheme: string): StyleGlyph {
         // The CJK fallback font specified by the developer takes precedence over the last resort fontstack in the style specification.
-        const usesLocalIdeographFontFamily = stack === defaultStack && this.localIdeographFontFamily !== '' && this._charUsesLocalIdeographFontFamily(id);
+        const usesLocalIdeographFontFamily = stack === defaultStack && this._charUsesLocalIdeographFontFamily(grapheme.codePointAt(0));
 
         // Keep a separate TinySDF instance for when we need to apply the localIdeographFontFamily fallback to keep the font selection from bleeding into non-CJK text.
         const tinySDFKey = usesLocalIdeographFontFamily ? 'ideographTinySDF' : 'tinySDF';
         entry[tinySDFKey] ||= this._createTinySDF(usesLocalIdeographFontFamily ? this.localIdeographFontFamily : stack);
-        const char = entry[tinySDFKey].draw(String.fromCodePoint(id));
+        const char = entry[tinySDFKey].draw(grapheme);
 
         /**
          * TinySDF's "top" is the distance from the alphabetic baseline to the top of the glyph.
@@ -195,7 +198,7 @@ export class GlyphManager {
         const isControl = /^\p{gc=Cf}+$/u.test(String.fromCodePoint(id));
 
         return {
-            id,
+            grapheme,
             bitmap: new AlphaImage({width: char.width || 30 * textureScale, height: char.height || 30 * textureScale}, char.data),
             metrics: {
                 width: isControl ? 0 : (char.glyphWidth / textureScale || 24),

--- a/src/render/glyph_manager.ts
+++ b/src/render/glyph_manager.ts
@@ -42,6 +42,11 @@ const defaultGenericFontFamily = 'sans-serif';
  */
 const textureScale = 2;
 
+/**
+ * Buffer around client-generated glyphs.
+ */
+const buffer = 10;
+
 export class GlyphManager {
     requestManager: RequestManager;
     localIdeographFontFamily: string | false;
@@ -183,7 +188,7 @@ export class GlyphManager {
             metrics: {
                 width: isControl ? 0 : (char.glyphWidth / textureScale || 24),
                 height: char.glyphHeight / textureScale || 24,
-                left: char.glyphLeft / textureScale || 0,
+                left: (char.glyphLeft - buffer) / textureScale || 0,
                 top: char.glyphTop / textureScale || 0,
                 advance: isControl ? 0 : (char.glyphAdvance / textureScale || 24),
                 isDoubleResolution: true
@@ -201,7 +206,7 @@ export class GlyphManager {
 
         return new GlyphManager.TinySDF({
             fontSize: 24 * textureScale,
-            buffer: 8 * textureScale,
+            buffer: buffer * textureScale,
             radius: 8 * textureScale,
             cutoff: 0.25,
             fontFamily: fontFamily,

--- a/src/render/glyph_manager.ts
+++ b/src/render/glyph_manager.ts
@@ -182,6 +182,8 @@ export class GlyphManager {
         entry[tinySDFKey] ||= this._createTinySDF(usesLocalIdeographFontFamily ? this.localIdeographFontFamily : stack);
         const char = entry[tinySDFKey].draw(grapheme);
 
+        const isControl = /^\p{gc=Cf}+$/u.test(grapheme);
+
         return {
             grapheme,
             bitmap: new AlphaImage({width: char.width || 30 * textureScale, height: char.height || 30 * textureScale}, char.data),

--- a/src/source/worker_source.ts
+++ b/src/source/worker_source.ts
@@ -85,7 +85,7 @@ export type WorkerTileWithData = ExpiryData & {
     // Only used for benchmarking:
     glyphMap?: {
         [_: string]: {
-            [_: number]: StyleGlyph;
+            [_: string]: StyleGlyph;
         };
     } | null;
     iconMap?: {

--- a/src/source/worker_tile.ts
+++ b/src/source/worker_tile.ts
@@ -127,9 +127,9 @@ export class WorkerTile {
             }
         }
 
-        // options.glyphDependencies looks like: {"SomeFontName":{"10":true,"32":true}}
-        // this line makes an object like: {"SomeFontName":[10,32]}
-        const stacks: {[_: string]: Array<number>} = mapObject(options.glyphDependencies, (glyphs) => Object.keys(glyphs).map(Number));
+        // options.glyphDependencies looks like: {"SomeFontName":{"A":true,"文":true}}
+        // this line makes an object like: {"SomeFontName":["A","文"]}
+        const stacks: {[_: string]: Array<string>} = mapObject(options.glyphDependencies, (glyphs) => Object.keys(glyphs));
 
         this.inFlightDependencies.forEach((request) => request?.abort());
         this.inFlightDependencies = [];

--- a/src/style/load_glyph_range.test.ts
+++ b/src/style/load_glyph_range.test.ts
@@ -26,11 +26,12 @@ test('loadGlyphRange', async ()  => {
     expect(transform).toHaveBeenCalledWith('https://localhost/fonts/v1/Arial Unicode MS/0-255.pbf', 'Glyphs');
 
     expect(Object.keys(result)).toHaveLength(223);
-    for (const key in result) {
-        const id = Number(key);
-        const glyph = result[id];
+    for (const grapheme in result) {
+        const glyph = result[grapheme];
 
-        expect(glyph.id).toBe(Number(id));
+        expect(typeof glyph.grapheme).toBe('string');
+        expect(glyph.grapheme).toBe(grapheme);
+        expect([...glyph.grapheme].length).toEqual(1);
         expect(glyph.metrics).toBeTruthy();
         expect(typeof glyph.metrics.width).toBe('number');
         expect(typeof glyph.metrics.height).toBe('number');

--- a/src/style/load_glyph_range.ts
+++ b/src/style/load_glyph_range.ts
@@ -9,7 +9,7 @@ import type {RequestManager} from '../util/request_manager';
 export async function loadGlyphRange(fontstack: string,
     range: number,
     urlTemplate: string,
-    requestManager: RequestManager): Promise<{[_: number]: StyleGlyph | null}> {
+    requestManager: RequestManager): Promise<{[_: string]: StyleGlyph | null}> {
     const begin = range * 256;
     const end = begin + 255;
 
@@ -25,7 +25,7 @@ export async function loadGlyphRange(fontstack: string,
     const glyphs = {};
 
     for (const glyph of parseGlyphPbf(response.data)) {
-        glyphs[glyph.id] = glyph;
+        glyphs[glyph.grapheme] = glyph;
     }
 
     return glyphs;

--- a/src/style/parse_glyph_pbf.ts
+++ b/src/style/parse_glyph_pbf.ts
@@ -15,7 +15,7 @@ function readFontstack(tag: number, glyphs: Array<StyleGlyph>, pbf: Protobuf) {
     if (tag === 3) {
         const {id, bitmap, width, height, left, top, advance} = pbf.readMessage(readGlyph, {});
         glyphs.push({
-            id,
+            grapheme: String.fromCodePoint(id),
             bitmap: new AlphaImage({
                 width: width + 2 * border,
                 height: height + 2 * border

--- a/src/style/style_glyph.ts
+++ b/src/style/style_glyph.ts
@@ -19,7 +19,7 @@ export type GlyphMetrics = {
  * A style glyph type
  */
 export type StyleGlyph = {
-    id: number;
+    grapheme: string;
     bitmap: AlphaImage;
     metrics: GlyphMetrics;
 };

--- a/src/style/style_layer/variable_text_anchor.ts
+++ b/src/style/style_layer/variable_text_anchor.ts
@@ -23,7 +23,7 @@ export type TextAnchor = keyof typeof TextAnchorEnum;
 // But in the vertical direction, the glyphs appear to "start" at the baseline
 // We don't actually load baseline data, but we assume an offset of ONE_EM - 17
 // (see "yOffset" in shaping.js)
-const baselineOffset = 7;
+const baselineOffset = 0;
 export const INVALID_TEXT_OFFSET = Number.POSITIVE_INFINITY;
 
 export function evaluateVariableOffset(anchor: TextAnchor, offset: [number, number]): [number, number] {

--- a/src/symbol/shaping.ts
+++ b/src/symbol/shaping.ts
@@ -4,7 +4,8 @@ import {
 import {
     charIsWhitespace,
     charInComplexShapingScript,
-    segmenter
+    segmenter,
+    splitByGraphemeCluster
 } from '../util/script_detection';
 import {rtlWorkerPlugin} from '../source/rtl_text_plugin_worker';
 import ONE_EM from './one_em';
@@ -154,7 +155,7 @@ function shapeText(
         // Convert grapheme cluster–based section index to be based on code units.
         let i = 0;
         const sectionIndex = [];
-        for (const {segment} of segmenter.segment(logicalInput.text)) {
+        for (const {segment} of splitByGraphemeCluster(logicalInput.text)) {
             sectionIndex.push(...Array(segment.length).fill(logicalInput.sectionIndex[i]));
             i++;
         }
@@ -164,7 +165,7 @@ function shapeText(
         for (const line of processedLines) {
             const sectionIndex = [];
             let elapsedChars = '';
-            for (const {segment} of segmenter.segment(line[0])) {
+            for (const {segment} of splitByGraphemeCluster(line[0])) {
                 sectionIndex.push(line[1][elapsedChars.length]);
                 elapsedChars += segment;
             }
@@ -338,7 +339,7 @@ function shapeLines(shaping: Shaping,
         const lineShapingSize = calculateLineContentSize(imagePositions, line, layoutTextSizeFactor);
 
         let i = 0;
-        for (const {segment} of segmenter.segment(line.text)) {
+        for (const {segment} of splitByGraphemeCluster(line.text)) {
             const section = line.getSection(i);
             const codePoint = segment.codePointAt(0);
             const vertical = isLineVertical(writingMode, allowVerticalPlacement, codePoint);

--- a/src/symbol/shaping.ts
+++ b/src/symbol/shaping.ts
@@ -25,7 +25,7 @@ enum WritingMode {
     horizontalOnly = 3
 }
 
-const SHAPING_DEFAULT_OFFSET = -17;
+const SHAPING_DEFAULT_OFFSET = 0;
 export {shapeText, shapeIcon, applyTextFit, fitIconToText, getAnchorAlignment, WritingMode, SHAPING_DEFAULT_OFFSET};
 
 // The position of a glyph relative to the text's anchor point.

--- a/src/symbol/symbol_layout.ts
+++ b/src/symbol/symbol_layout.ts
@@ -66,7 +66,7 @@ export function performSymbolLayout(args: {
     bucket: SymbolBucket;
     glyphMap: {
         [_: string]: {
-            [x: number]: StyleGlyph;
+            [x: string]: StyleGlyph;
         };
     };
     glyphPositions: {

--- a/src/symbol/tagged_string.test.ts
+++ b/src/symbol/tagged_string.test.ts
@@ -18,13 +18,6 @@ describe('TaggedString', () => {
         });
     });
 
-    describe('hasZeroWidthSpaces', () => {
-        test('detects a zero width space', () => {
-            const tagged = new TaggedString('三三\u200b三三\u200b三三\u200b三三三三三三\u200b三三');
-            expect(tagged.hasZeroWidthSpaces()).toBeTruthy();
-        });
-    });
-
     describe('trim', () => {
         test('turns a whitespace-only string into the empty string', () => {
             const tagged = new TaggedString('  \t    \v ', [textSection], Array(9).fill(0));

--- a/src/symbol/tagged_string.test.ts
+++ b/src/symbol/tagged_string.test.ts
@@ -1,6 +1,7 @@
 import {describe, test, expect} from 'vitest';
 
 import type {StyleGlyph} from '../style/style_glyph';
+import {AlphaImage} from '../util/image';
 import {TaggedString, type TextSectionOptions} from './tagged_string';
 
 describe('TaggedString', () => {
@@ -76,20 +77,18 @@ describe('TaggedString', () => {
             top: -8,
             advance: 22,
         };
-        const rect = {
-            x: 0,
-            y: 0,
-            w: 32,
-            h: 32,
-        };
+        const bitmap = new AlphaImage({
+            width: 32,
+            height: 32,
+        });
         const glyphs = {
             'Test': {
-                '97': {id: 0x61, metrics, rect},
-                '98': {id: 0x62, metrics, rect},
-                '99': {id: 0x63, metrics, rect},
-                '40629': {id: 0x9EB5, metrics, rect},
-                '200414': {id: 0x30EDE, metrics, rect},
-            } as any as StyleGlyph,
+                'a': {grapheme: 'a', bitmap, metrics} as StyleGlyph,
+                'b': {grapheme: 'b', bitmap, metrics} as StyleGlyph,
+                'c': {grapheme: 'c', bitmap, metrics} as StyleGlyph,
+                '麵': {grapheme: '麵', bitmap, metrics} as StyleGlyph,
+                '𰻞': {grapheme: '𰻞', bitmap, metrics} as StyleGlyph,
+            },
         };
         const textSection = {
             scale: 1,

--- a/src/symbol/tagged_string.ts
+++ b/src/symbol/tagged_string.ts
@@ -4,7 +4,7 @@ import ONE_EM from './one_em';
 import type {ImagePosition} from '../render/image_atlas';
 import type {StyleGlyph} from '../style/style_glyph';
 import {verticalizePunctuation} from '../util/verticalize_punctuation';
-import {charIsWhitespace, segmenter} from '../util/script_detection';
+import {charIsWhitespace, segmenter, splitByGraphemeCluster} from '../util/script_detection';
 import {codePointAllowsIdeographicBreaking} from '../util/unicode_properties.g';
 import {warnOnce} from '../util/util';
 
@@ -199,7 +199,7 @@ export class TaggedString {
     }
 
     length(): number {
-        return Array.from(segmenter.segment(this.text)).length;
+        return splitByGraphemeCluster(this.text).length;
     }
 
     getSection(index: number): SectionOptions {
@@ -235,7 +235,7 @@ export class TaggedString {
     }
 
     substring(start: number, end: number): TaggedString {
-        const text = Array.from(segmenter.segment(this.text)).slice(start, end).map(s => s.segment).join('');
+        const text = splitByGraphemeCluster(this.text).slice(start, end).map(s => s.segment).join('');
         const sectionIndex = this.sectionIndex.slice(start, end);
         return new TaggedString(text, this.sections, sectionIndex);
     }
@@ -244,7 +244,7 @@ export class TaggedString {
      * Converts a grapheme cluster index to a UTF-16 code unit (JavaScript character index).
      */
     toCodeUnitIndex(unicodeIndex: number): number {
-        return Array.from(segmenter.segment(this.text)).slice(0, unicodeIndex).map(s => s.segment).join('').length;
+        return splitByGraphemeCluster(this.text).slice(0, unicodeIndex).map(s => s.segment).join('').length;
     }
 
     toString(): string {
@@ -282,7 +282,7 @@ export class TaggedString {
             fontStack: section.fontStack || defaultFontStack,
         } as TextSectionOptions);
         const index = this.sections.length - 1;
-        this.sectionIndex.push(...[...segmenter.segment(section.text)].map(() => index));
+        this.sectionIndex.push(...splitByGraphemeCluster(section.text).map(() => index));
     }
 
     addImageSection(section: FormattedSection) {
@@ -336,12 +336,12 @@ export class TaggedString {
         let currentX = 0;
 
         let i = 0;
-        const chars = segmenter.segment(this.text)[Symbol.iterator]();
+        const chars = splitByGraphemeCluster(this.text)[Symbol.iterator]();
         let char = chars.next();
-        const nextChars = segmenter.segment(this.text)[Symbol.iterator]();
+        const nextChars = splitByGraphemeCluster(this.text)[Symbol.iterator]();
         nextChars.next();
         let nextChar = nextChars.next();
-        const nextNextChars = segmenter.segment(this.text)[Symbol.iterator]();
+        const nextNextChars = splitByGraphemeCluster(this.text)[Symbol.iterator]();
         nextNextChars.next();
         nextNextChars.next();
         let nextNextChar = nextNextChars.next();
@@ -400,7 +400,7 @@ export class TaggedString {
         let totalWidth = 0;
 
         let index = 0;
-        for (const {segment} of segmenter.segment(this.text)) {
+        for (const {segment} of splitByGraphemeCluster(this.text)) {
             const section = this.getSection(index);
             totalWidth += getGlyphAdvance(segment, section, glyphMap, imagePositions, spacing, layoutTextSize);
             index++;

--- a/src/util/actor_messages.ts
+++ b/src/util/actor_messages.ts
@@ -63,7 +63,7 @@ export type GetImagesParameters = {
  */
 export type GetGlyphsParameters = {
     type: string;
-    stacks: {[_: string]: Array<number>};
+    stacks: {[_: string]: Array<string>};
     source: string;
     tileID: OverscaledTileID;
 };
@@ -73,7 +73,7 @@ export type GetGlyphsParameters = {
  */
 export type GetGlyphsResponse = {
     [stack: string]: {
-        [id: number]: StyleGlyph;
+        [grapheme: string]: StyleGlyph;
     };
 };
 

--- a/src/util/script_detection.test.ts
+++ b/src/util/script_detection.test.ts
@@ -1,5 +1,5 @@
 import {describe, test, expect} from 'vitest';
-import {charIsWhitespace, charAllowsLetterSpacing, charInComplexShapingScript, charInRTLScript} from './script_detection';
+import {charIsWhitespace, charAllowsLetterSpacing, charInComplexShapingScript, stringContainsRTLText} from './script_detection';
 
 describe('charIsWhitespace', () => {
     test('detects whitespace', () => {
@@ -52,35 +52,35 @@ describe('charInComplexShapingScript', () => {
     });
 });
 
-describe('charInRTLScript', () => {
+describe('stringContainsRTLText', () => {
     test('does not identify direction-neutral text as right-to-left', () => {
-        expect(charInRTLScript('3'.codePointAt(0))).toBe(false);
+        expect(stringContainsRTLText('3')).toBe(false);
     });
 
     test('identifies Arabic text as right-to-left', () => {
         // Arabic
-        expect(charInRTLScript('۳'.codePointAt(0))).toBe(true);
+        expect(stringContainsRTLText('۳')).toBe(true);
         // Arabic Supplement
-        expect(charInRTLScript('ݣ'.codePointAt(0))).toBe(true);
+        expect(stringContainsRTLText('ݣ')).toBe(true);
         // Arabic Extended-A
-        expect(charInRTLScript('ࢳ'.codePointAt(0))).toBe(true);
+        expect(stringContainsRTLText('ࢳ')).toBe(true);
         // Arabic Extended-B
-        expect(charInRTLScript('࢐'.codePointAt(0))).toBe(true);
+        expect(stringContainsRTLText('࢐')).toBe(true);
         // Arabic Presentation Forms-A
-        expect(charInRTLScript('ﰤ'.codePointAt(0))).toBe(true);
+        expect(stringContainsRTLText('ﰤ')).toBe(true);
         // Arabic Presentation Forms-B
-        expect(charInRTLScript('ﺽ'.codePointAt(0))).toBe(true);
+        expect(stringContainsRTLText('ﺽ')).toBe(true);
     });
 
     test('identifies Hebrew text as right-to-left', () => {
         // Hebrew
-        expect(charInRTLScript('ה'.codePointAt(0))).toBe(true);
+        expect(stringContainsRTLText('ה')).toBe(true);
         // Alphabetic Presentation Forms
-        expect(charInRTLScript('ﬡ'.codePointAt(0))).toBe(true);
+        expect(stringContainsRTLText('ﬡ')).toBe(true);
     });
 
     test('identifies Thaana text as right-to-left', () => {
         // Thaana
-        expect(charInRTLScript('ޘ'.codePointAt(0))).toBe(true);
+        expect(stringContainsRTLText('ޘ')).toBe(true);
     });
 });

--- a/src/util/script_detection.test.ts
+++ b/src/util/script_detection.test.ts
@@ -1,5 +1,5 @@
 import {describe, test, expect} from 'vitest';
-import {charIsWhitespace, charAllowsLetterSpacing, charInComplexShapingScript, stringContainsRTLText} from './script_detection';
+import {allowsLetterSpacing, charIsWhitespace, charInComplexShapingScript, stringContainsRTLText} from './script_detection';
 
 describe('charIsWhitespace', () => {
     test('detects whitespace', () => {
@@ -12,24 +12,24 @@ describe('charIsWhitespace', () => {
     });
 });
 
-describe('charAllowsLetterSpacing', () => {
+describe('allowsLetterSpacing', () => {
     test('allows letter spacing of Latin text', () => {
-        expect(charAllowsLetterSpacing('A'.codePointAt(0))).toBe(true);
+        expect(allowsLetterSpacing('A')).toBe(true);
     });
 
     test('disallows ideographic breaking of Arabic text', () => {
         // Arabic
-        expect(charAllowsLetterSpacing('۳'.codePointAt(0))).toBe(false);
+        expect(allowsLetterSpacing('۳')).toBe(false);
         // Arabic Supplement
-        expect(charAllowsLetterSpacing('ݣ'.codePointAt(0))).toBe(false);
+        expect(allowsLetterSpacing('ݣ')).toBe(false);
         // Arabic Extended-A
-        expect(charAllowsLetterSpacing('ࢳ'.codePointAt(0))).toBe(false);
+        expect(allowsLetterSpacing('ࢳ')).toBe(false);
         // Arabic Extended-B
-        expect(charAllowsLetterSpacing('࢐'.codePointAt(0))).toBe(false);
+        expect(allowsLetterSpacing('࢐')).toBe(false);
         // Arabic Presentation Forms-A
-        expect(charAllowsLetterSpacing('ﰤ'.codePointAt(0))).toBe(false);
+        expect(allowsLetterSpacing('ﰤ')).toBe(false);
         // Arabic Presentation Forms-B
-        expect(charAllowsLetterSpacing('ﺽ'.codePointAt(0))).toBe(false);
+        expect(allowsLetterSpacing('ﺽ')).toBe(false);
     });
 });
 

--- a/src/util/script_detection.test.ts
+++ b/src/util/script_detection.test.ts
@@ -17,7 +17,7 @@ describe('allowsLetterSpacing', () => {
         expect(allowsLetterSpacing('A')).toBe(true);
     });
 
-    test('disallows ideographic breaking of Arabic text', () => {
+    test('disallows letter spacing of Arabic text', () => {
         // Arabic
         expect(allowsLetterSpacing('۳')).toBe(false);
         // Arabic Supplement

--- a/src/util/script_detection.ts
+++ b/src/util/script_detection.ts
@@ -75,7 +75,7 @@ function sanitizedRegExpFromScriptCodes(scriptCodes: Array<string>): RegExp {
             return null;
         }
     }).filter(pe => pe);
-    return new RegExp(supportedPropertyEscapes.join('|'), 'u');
+    return new RegExp(`[${supportedPropertyEscapes.join('')}]`, 'u');
 }
 
 /**

--- a/src/util/script_detection.ts
+++ b/src/util/script_detection.ts
@@ -18,6 +18,53 @@ export function charIsWhitespace(char: number) {
     return /\s/u.test(String.fromCodePoint(char));
 }
 
+// Indic_Syllabic_Category=Invisible_Stacker as of Unicode 16.0.0.
+// https://www.unicode.org/Public/UCD/latest/ucd/IndicSyllabicCategory.txt
+const invisibleStackerCodePoints = [
+    0x1039, // MYANMAR SIGN VIRAMA
+    0x17D2, // KHMER SIGN COENG
+    0x1A60, // TAI THAM SIGN SAKOT
+    0x1BAB, // SUNDANESE SIGN VIRAMA
+    0xAAF6, // MEETEI MAYEK VIRAMA
+    0x10A3F, // KHAROSHTHI VIRAMA
+    0x11133, // CHAKMA VIRAMA
+    0x113D0, // TULU-TIGALARI CONJOINER
+    0x1193E, // DIVES AKURU VIRAMA
+    0x11A47, // ZANABAZAR SQUARE SUBJOINER
+    0x11A99, // SOYOMBO SUBJOINER
+    0x11D45, // MASARAM GONDI VIRAMA
+    0x11D97, // GUNJALA GONDI VIRAMA
+    0x11F42, // KAWI CONJOINER
+];
+
+const invisibleStackersCharClass = invisibleStackerCodePoints.map(cp => `\\u{${cp.toString(16)}}`);
+const invisibleStackersRegExp = new RegExp(`[${invisibleStackersCharClass}]$`, 'u');
+
+export function splitByGraphemeCluster(text: string) {
+    const segments = segmenter.segment(text)[Symbol.iterator]();
+    let segment = segments.next();
+    const nextSegments = segmenter.segment(text)[Symbol.iterator]();
+    nextSegments.next();
+    let nextSegment = nextSegments.next();
+
+    const baseSegments = [];
+    while (!segment.done) {
+        const baseSegment = segment;
+        while (!nextSegment.done &&
+               (/^\p{gc=Mc}/u.test(nextSegment.value.segment) ||
+				invisibleStackersRegExp.test(baseSegment.value.segment))) {
+            baseSegment.value.segment += nextSegment.value.segment;
+            segment = segments.next();
+            nextSegment = nextSegments.next();
+        }
+        baseSegments.push(baseSegment.value);
+        segment = segments.next();
+        nextSegment = nextSegments.next();
+    }
+
+    return baseSegments;
+}
+
 export function allowsIdeographicBreaking(chars: string) {
     for (const char of chars) {
         if (!codePointAllowsIdeographicBreaking(char.codePointAt(0))) return false;

--- a/src/util/script_detection.ts
+++ b/src/util/script_detection.ts
@@ -57,10 +57,7 @@ export function allowsVerticalWritingMode(chars: string) {
 }
 
 export function allowsLetterSpacing(chars: string) {
-    for (const char of chars) {
-        if (!charAllowsLetterSpacing(char.codePointAt(0))) return false;
-    }
-    return true;
+    return !cursiveScriptRegExp.test(chars);
 }
 
 /**
@@ -93,10 +90,6 @@ const cursiveScriptCodes = [
 ];
 
 const cursiveScriptRegExp = sanitizedRegExpFromScriptCodes(cursiveScriptCodes);
-
-export function charAllowsLetterSpacing(char: number) {
-    return !cursiveScriptRegExp.test(String.fromCodePoint(char));
-}
 
 /**
  * Returns true if the given Unicode codepoint identifies a character with

--- a/src/util/script_detection.ts
+++ b/src/util/script_detection.ts
@@ -1,17 +1,20 @@
 import {
     canCombineGraphemes,
-    codePointAllowsIdeographicBreaking,
     codePointHasUprightVerticalOrientation,
     codePointHasNeutralVerticalOrientation,
     codePointRequiresComplexTextShaping
 } from '../util/unicode_properties.g';
 
 export const segmenter = ('Segmenter' in Intl) ? new Intl.Segmenter() : {
-    segment: (text: String) => {
-        return [...text].map((char, index) => ({
+    segment: (text: string) => {
+        const segments = [...text].map((char, index) => ({
             index,
             segment: char,
         }));
+        return {
+            containing: (index: number) => segments.find(s => s.index <= index && s.index + s.segment.length > index),
+            [Symbol.iterator]: () => segments[Symbol.iterator](),
+        };
     },
 };
 
@@ -40,13 +43,6 @@ export function splitByGraphemeCluster(text: string) {
     }
 
     return baseSegments;
-}
-
-export function allowsIdeographicBreaking(chars: string) {
-    for (const char of chars) {
-        if (!codePointAllowsIdeographicBreaking(char.codePointAt(0))) return false;
-    }
-    return true;
 }
 
 export function allowsVerticalWritingMode(chars: string) {

--- a/src/util/script_detection.ts
+++ b/src/util/script_detection.ts
@@ -5,6 +5,15 @@ import {
     codePointRequiresComplexTextShaping
 } from '../util/unicode_properties.g';
 
+export const segmenter = ('Segmenter' in Intl) ? new Intl.Segmenter() : {
+    segment: (text: String) => {
+        return [...text].map((char, index) => ({
+            index,
+            segment: char,
+        }));
+    },
+};
+
 export function charIsWhitespace(char: number) {
     return /\s/u.test(String.fromCodePoint(char));
 }

--- a/src/util/script_detection.ts
+++ b/src/util/script_detection.ts
@@ -161,10 +161,6 @@ const rtlScriptCodes = [
 
 const rtlScriptRegExp = sanitizedRegExpFromScriptCodes(rtlScriptCodes);
 
-export function charInRTLScript(char: number) {
-    return rtlScriptRegExp.test(String.fromCodePoint(char));
-}
-
 export function charInSupportedScript(char: number, canRenderRTL: boolean) {
     // This is a rough heuristic: whether we "can render" a script
     // actually depends on the properties of the font being used
@@ -173,7 +169,7 @@ export function charInSupportedScript(char: number, canRenderRTL: boolean) {
 
     // Even in Latin script, we "can't render" combinations such as the fi
     // ligature, but we don't consider that semantically significant.
-    if (!canRenderRTL && charInRTLScript(char)) {
+    if (!canRenderRTL && rtlScriptRegExp.test(String.fromCodePoint(char))) {
         return false;
     }
     if (codePointRequiresComplexTextShaping(char)) {
@@ -183,12 +179,7 @@ export function charInSupportedScript(char: number, canRenderRTL: boolean) {
 }
 
 export function stringContainsRTLText(chars: string): boolean {
-    for (const char of chars) {
-        if (charInRTLScript(char.codePointAt(0))) {
-            return true;
-        }
-    }
-    return false;
+    return rtlScriptRegExp.test(chars);
 }
 
 export function isStringInSupportedScript(chars: string, canRenderRTL: boolean) {

--- a/src/util/script_detection.ts
+++ b/src/util/script_detection.ts
@@ -159,7 +159,7 @@ const rtlScriptCodes = [
     'Yezi', // Yezidi
 ];
 
-const rtlScriptRegExp = sanitizedRegExpFromScriptCodes(rtlScriptCodes);
+export const rtlScriptRegExp = sanitizedRegExpFromScriptCodes(rtlScriptCodes);
 
 export function charInSupportedScript(char: number, canRenderRTL: boolean) {
     // This is a rough heuristic: whether we "can render" a script

--- a/src/util/script_detection.ts
+++ b/src/util/script_detection.ts
@@ -1,4 +1,5 @@
 import {
+    canCombineGraphemes,
     codePointAllowsIdeographicBreaking,
     codePointHasUprightVerticalOrientation,
     codePointHasNeutralVerticalOrientation,
@@ -18,28 +19,6 @@ export function charIsWhitespace(char: number) {
     return /\s/u.test(String.fromCodePoint(char));
 }
 
-// Indic_Syllabic_Category=Invisible_Stacker as of Unicode 16.0.0.
-// https://www.unicode.org/Public/UCD/latest/ucd/IndicSyllabicCategory.txt
-const invisibleStackerCodePoints = [
-    0x1039, // MYANMAR SIGN VIRAMA
-    0x17D2, // KHMER SIGN COENG
-    0x1A60, // TAI THAM SIGN SAKOT
-    0x1BAB, // SUNDANESE SIGN VIRAMA
-    0xAAF6, // MEETEI MAYEK VIRAMA
-    0x10A3F, // KHAROSHTHI VIRAMA
-    0x11133, // CHAKMA VIRAMA
-    0x113D0, // TULU-TIGALARI CONJOINER
-    0x1193E, // DIVES AKURU VIRAMA
-    0x11A47, // ZANABAZAR SQUARE SUBJOINER
-    0x11A99, // SOYOMBO SUBJOINER
-    0x11D45, // MASARAM GONDI VIRAMA
-    0x11D97, // GUNJALA GONDI VIRAMA
-    0x11F42, // KAWI CONJOINER
-];
-
-const invisibleStackersCharClass = invisibleStackerCodePoints.map(cp => `\\u{${cp.toString(16)}}`);
-const invisibleStackersRegExp = new RegExp(`[${invisibleStackersCharClass}]$`, 'u');
-
 export function splitByGraphemeCluster(text: string) {
     const segments = segmenter.segment(text)[Symbol.iterator]();
     let segment = segments.next();
@@ -50,9 +29,7 @@ export function splitByGraphemeCluster(text: string) {
     const baseSegments = [];
     while (!segment.done) {
         const baseSegment = segment;
-        while (!nextSegment.done &&
-               (/^\p{gc=Mc}/u.test(nextSegment.value.segment) ||
-				invisibleStackersRegExp.test(baseSegment.value.segment))) {
+        while (!nextSegment.done && canCombineGraphemes(baseSegment.value.segment, nextSegment.value.segment)) {
             baseSegment.value.segment += nextSegment.value.segment;
             segment = segments.next();
             nextSegment = nextSegments.next();

--- a/src/util/verticalize_punctuation.ts
+++ b/src/util/verticalize_punctuation.ts
@@ -87,26 +87,28 @@ export const verticalizedCharacterMap = {
     '｣': '﹂'
 };
 
+const segmenter = new Intl.Segmenter();
+
 export function verticalizePunctuation(input: string) {
     let output = '';
 
     let prevChar = {premature: true, value: undefined};
-    const chars = input[Symbol.iterator]();
+    const chars = segmenter.segment(input)[Symbol.iterator]();
     let char = chars.next();
-    const nextChars = input[Symbol.iterator]();
+    const nextChars = segmenter.segment(input)[Symbol.iterator]();
     nextChars.next();
     let nextChar = nextChars.next();
 
     while (!char.done) {
         const canReplacePunctuation = (
-            (nextChar.done || !charHasRotatedVerticalOrientation(nextChar.value.codePointAt(0)) || verticalizedCharacterMap[nextChar.value]) &&
-            (prevChar.premature || !charHasRotatedVerticalOrientation(prevChar.value.codePointAt(0)) || verticalizedCharacterMap[prevChar.value])
+            (nextChar.done || !charHasRotatedVerticalOrientation(nextChar.value.segment.codePointAt(0)) || verticalizedCharacterMap[nextChar.value.segment]) &&
+            (prevChar.premature || !charHasRotatedVerticalOrientation(prevChar.value.segment.codePointAt(0)) || verticalizedCharacterMap[prevChar.value.segment])
         );
 
-        if (canReplacePunctuation && verticalizedCharacterMap[char.value]) {
-            output += verticalizedCharacterMap[char.value];
+        if (canReplacePunctuation && verticalizedCharacterMap[char.value.segment]) {
+            output += verticalizedCharacterMap[char.value.segment];
         } else {
-            output += char.value;
+            output += char.value.segment;
         }
 
         prevChar = {value: char.value, premature: false};

--- a/test/integration/symbol-shaping/shaping.test.ts
+++ b/test/integration/symbol-shaping/shaping.test.ts
@@ -6,6 +6,7 @@ import {ResolvedImage, Formatted, FormattedSection, type VerticalAlign} from '@m
 import {ImagePosition} from '../../../src/render/image_atlas';
 import type {StyleImage} from '../../../src/style/style_image';
 import type {StyleGlyph} from '../../../src/style/style_glyph';
+import {AlphaImage} from '../../../src/util/image';
 
 import glyphsJson from '../assets/glyphs/fontstack-glyphs.json' with {type: 'json'};
 import expectedJson from './tests/text-shaping-linebreak.json' with {type: 'json'};
@@ -35,10 +36,31 @@ describe('shaping', () => {
     const layoutTextSize = 16;
     const layoutTextSizeThisZoom = 16;
     const fontStack = 'Test';
+    // TODO: Change the keys in fontstack-glyphs.json to strings.
     const glyphs = {
-        'Test': glyphsJson as any as StyleGlyph
+        'Test': Object.fromEntries(Object.entries(glyphsJson).map(entry => {
+            const bitmap = new AlphaImage({
+                width: entry[1].rect.w,
+                height: entry[1].rect.h,
+            });
+            const glyph = {
+                grapheme: String.fromCodePoint(entry[1].id),
+                bitmap,
+                metrics: entry[1].metrics,
+            } as StyleGlyph;
+            return [entry[0], glyph];
+        }))
     };
-    const glyphPositions = glyphs;
+    const glyphPositions = {
+        'Test': Object.fromEntries(Object.entries(glyphsJson).map(entry => {
+            const position = {
+                grapheme: String.fromCodePoint(entry[1].id),
+                rect: entry[1].rect,
+                metrics: entry[1].metrics,
+            };
+            return [entry[0], position];
+        }))
+    };
 
     const images = {
         'square': new ImagePosition({x: 0, y: 0, w: 16, h: 16}, {pixelRatio: 1, version: 1} as StyleImage),


### PR DESCRIPTION
This branch adds experimental support for rendering text in Indic and other complex scripts, variant character forms, and combining diacritics. As a side effect, some emoji sequences now appear as single glyphs, though only as silhouettes.

![The names of Bengaluru in various Indian languages curved around two concentric circles and of Naypyidaw in Burmese in another concentric circle. Indic text is properly shaped without any dangling or misplaced diacritical marks. In the corner, a few rows of miscellaneous CJK text, including a rare kanji. Below it, a label that contains an Egyptian hieroglyph of an elephant, a flag emoji sequence, wheelchair emoji, and woman in wheelchair emoji. The emoji are only silhouettes rather than in color. Below that, the name of Kolkata in Hindi with a gloss in English and the name of Sri Lanka in Sinhala. The syllable “sri” appears as a single ligature. To the left, the name of the Democratic Republic of Congo in Maldivian and some text in Central Kurdish and Arabic. Maldivian diacritics appear over the correct letters. Collision boxes are enabled.](https://github.com/user-attachments/assets/2a158c08-2e9e-468c-a387-5d290ee255a9)

## Text segmentation

Currently, `text-field` strings are segmented by UTF-16 code units. maplibre/maplibre-gl-js#4550 refactors various text processing classes to segment by full UTF-16 characters instead, expanding text rendering support to the rest of the Unicode character repertoire. However, in many common situations, a single Unicode character in isolation cannot adequately represent a _grapheme cluster_ that the user perceives as a single glyph. This branch segments strings by grapheme cluster for rendering purposes. Additionally, it refactors the glyph atlas to index glyph data by grapheme cluster strings, whereas currently it is indexed by codepoints. (Actually, the codepoints are converted to numbers and then stringified for maximum inefficiency, apparently for consistency with the glyph PBF format.)

Segmenting strings by grapheme cluster requires the [`Intl.Segmenter`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Segmenter) API, which is very new. Firefox was the last major holdout, adding support for this API only a few months ago. For older browsers, it will be necessary to fall back to segmenting by Unicode character. Grapheme cluster segmentation is not a panacea: https://github.com/maplibre/maplibre-native/discussions/778#discussioncomment-5763956 discusses some limitations around cursive scripts. Unless a workaround can be found, mapbox-gl-rtl-text plugin will probably continue to be required for Arabic typesetting.

The segmenter understands emoji sequences, including sequences that include zero-width joiners. However, it is only possible to render the emoji’s silhouette for the time being, because the glyph atlas only stores the alpha channel of the glyph image. [Storing each of the color channels](https://gpuhacks.wordpress.com/2013/07/08/signed-distance-field-rendering-of-color-bit-planes/) would enable the shader to draw color emoji, as demonstrated in 1ec5/tiny-sdf#1, but it would need to be limited to detected emoji sequences to avoid largely frivolous overhead.

The custom word breaking heuristics for determining line breaking opportunities have been replaced by a word segmenter. This introduces word wrapping for the first time to writing systems such as Thai and Khmer that don’t put spaces between words. It also keeps Hanzi/hanja/kanji compound words together based on the browser’s built-in compound dictionary. This obviates the server-side workaround that Mapbox introduced in mapbox/mapbox-gl-js#8255 (before the fork). If a tileset has inserted zero-width spaces between compounds as hints, as the [Mapbox Streets](https://docs.mapbox.com/data/tilesets/reference/mapbox-streets-v8/#names) source does, the word segmenter will continue to honor those hints as a matter of course, but this functionality now comes “for free” without any developer intervention.

## Local text rendering

As TinySDF is my hammer, everything looks like a nail. This branch completely disables the glyph PBF pipeline for remotely rendered glyphs in favor of rendering every grapheme cluster locally through TinySDF, making maplibre/maplibre-gl-js#4564 unnecessary. The changes obviate much of the original reason that Mapbox created a Fontstack API and defined the glyph PBF format.

The expanded use of TinySDF creates a need for more granular control over font selection beyond the single font specifier for local “ideographic” text. The developer can already set the font specifier to the name of a Web font defined in the surrounding webpage’s stylesheet. However, this option is currently global; the font choice should come instead from `text-font`, which is no longer used for remote glyph rendering. An event handler will need to be added to call `Map.prototype.redraw` once any Web fonts are done loading.

Vertical alignment has often been cited as a downside of TinySDF, but it’s actually the glyph PBFs that are to blame. Glyph PBFs don’t encode enough glyph metrics to reliably align glyphs to a common baseline, so there were hard-coded fudge factors in a few different places in the codebase to vertically shift locally rendered glyphs to match remotely rendered glyphs. These fudge factors assume the metrics of Arial Unicode MS, which is the default `text-font` fallback but is also an outlier for its line height, even among pan-Unicode fonts. With the removal of the glyph PBF mechanism, it becomes possible to remove these fudge factors.

In theory, it should be possible to use TinySDF only for grapheme clusters that can’t be represented by the glyph PBF format. However, that would yield extremely inconsistent visual results, because most scripts that contain nontrivial grapheme clusters also have plenty of unclustered graphemes sprinkled throughout in ordinary text. If backwards compatibility with older styles is a concern, I believe it would be better to render ~~glyphs~~ grapheme clusters locally in general and _at most_ render Latin, Cyrillic, and Greek from glyph PBFs as an exception.

The glyph PBF mechanism has been primarily of use to Western languages. Most published fontstacks consist of one or two specially chosen Western fonts combined with a crude, pan-Unicode font as an afterthought to serve as a fallback for the rest of the world’s languages. While the glyph PBF format has the advantage of not requiring embedding and redistribution rights from the font designer, the most popular fonts for non-Western languages are generally open-source fonts that can be served up as Web fonts and rendered through TinySDF without any legal obstacles.

## Prior art

maplibre/maplibre-gl-js#2458 similarly relies on TinySDF for all text. However, it requires the tileset or GeoJSON data to include manually placed control characters to mark grapheme cluster boundaries. I think any required server-side hinting would significantly limit the deployment of complex text rendering to end users, as Mapbox discovered early on: https://github.com/mapbox/DEPRECATED-mapbox-gl/issues/4#issuecomment-242967072. Even though `Intl.Segmenter` still falls short of the gold standard in Harfbuzz/Raqm/FriBiDi, it comes with such low overhead that GL JS might as well take advantage of it rather than allow Indic text to continue to get mangled.

## Odds and ends

This branch also includes some miscellaneous fixes for things I spotted along the way. Some types were misspelled. Some unit tests relied on outdated fixtures that cast incompatible data to the expected data type; TypeScript only started flagging it once I modified the types just a little more.

These changes would fix maplibre/maplibre-gl-js#50 and maplibre/maplibre-gl-js#2384. I’m posting this draft in my own fork for now while I consider how to stage these changes in more manageable chunks and discuss the backwards compatibility issues with the MapLibre maintainers.

Additionally, the following proofs of concept are based on this one:

* #2
* #3